### PR TITLE
Read PKCS#8. New (PEM:READ-PEM) takes files, streams and strings, handling both PKCS#1 and PCKS#8.

### DIFF
--- a/main.lisp
+++ b/main.lisp
@@ -4,14 +4,6 @@
         #:pem/pkey)
   (:export #:parse
            #:parse-file
-           #:read-from-file))
+           #:read-from-file
+           #:read-pem))
 (in-package #:pem)
-
-
-
-
-
-
-
-
-

--- a/parser.lisp
+++ b/parser.lisp
@@ -8,7 +8,7 @@
 (in-package #:pem/parser)
 
 (defun parse (pem)
-  (assert (eq (stream-element-type pem) 'character))
+  (assert (member (stream-element-type pem) '(character base-char)))
   (loop for line = (read-line pem nil nil)
         while line
         collect (ppcre:register-groups-bind (label)

--- a/pkey.lisp
+++ b/pkey.lisp
@@ -6,11 +6,13 @@
                 #:decode
                 #:rsa-public-key-info)
   (:import-from #:trivia
-                #:match)
+                #:match
+                #:access)
   (:import-from #:cl-base64
                 #:base64-string-to-usb8-array)
   (:import-from #:ironclad)
-  (:export #:read-from-file))
+  (:export #:read-from-file
+           #:read-pem))
 (in-package #:pem/pkey)
 
 (defun read-public-key (key)
@@ -29,10 +31,50 @@
        (ironclad:make-private-key :rsa :d d :n n))
       (otherwise (error "Unexpected format: ~S" key)))))
 
-(defun read-from-file (pem)
-  (let ((data (pem/parser:parse-file pem)))
+(defun read-pkcs8-private-key (key)
+  "Returns an IRONCLAD:RSA-PRIVATE-KEY from a PKCS#8 private key.
+Only support RSA private keys."
+  (let* ((der (base64:base64-string-to-usb8-array key))
+         (der (asn1:decode der)))
+    (match der
+      ((list
+        (list*
+         :sequence
+         (list (cons :integer 0)      ; RFC5208: Version, must be 0
+               (cons
+                :sequence
+                (assoc
+                 :object-identifier   ; RFC5208: PrivKeyAlgId = RSA encryption OID
+                 #(1 2 840 113549 1 1 1)))
+               (cons
+                :octet-string         ; RFC5208: encoded private key
+                (access
+                 #'asn1:decode
+                 (asn1/format/rsa::rsa-private-key
+                  :private-exponent d
+                  :modulus n))))))
+       (ironclad:make-private-key :rsa :d d :n n))
+      (otherwise (error "Unexpected format: ~S" key)))))
+
+
+(defun read-key (data)
     (let ((public-key (cdr (assoc "PUBLIC KEY" data :test #'string=)))
-          (private-key (cdr (assoc "RSA PRIVATE KEY" data :test #'string=))))
+        (private-key (cdr (assoc "RSA PRIVATE KEY" data :test #'string=)))
+        (pkcs8-private-key (cdr (assoc "PRIVATE KEY" data :test #'string=))))
       (cond
         (public-key (read-public-key public-key))
-        (private-key (read-private-key private-key))))))
+      (private-key (read-private-key private-key))
+      (pkcs8-private-key (read-pkcs8-private-key pkcs8-private-key)))))
+
+(defun read-from-file (pem)
+  (let ((data (pem/parser:parse-file pem)))
+    (dispatch data)))
+
+(defgeneric read-pem (pem)
+  (:method ((pem pathname))
+    (read-from-file pem))
+  (:method ((pem stream))
+    (let ((data (pem/parser:parse pem)))
+      (read-key data)))
+  (:method ((pem string))
+    (read-pem (make-string-input-stream pem))))


### PR DESCRIPTION
Resolves issue #1.

`PEM:READ-PEM` is a generic function accepting pathnames, streams and strings.

`PEM:READ-PEM` as well as `PEM:READ-FROM-FILE` can both read PKCS#1 and PKCS#8 PEMs.

Relaxed an overly strict assertion which required `STREAM-ELEMENT-TYPE` to be `CHARACTER.` Now `BASE-CHAR` is also accepted; some libraries like `COM.INUOE.JZON` produce this type of strings.

This is a work in progress, I have only added support for PKCS#8 **private keys**. However adding its public key will be a minor variation of the private one.